### PR TITLE
Add go mod files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ by looking for 5xx responses.
 
 #### Option 2
 - Clone this repo into your $GOPATH.
-- Install dependencies with `go get`.
 - Build the binary with `go build`
 
 ## Example:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/luchkonikita/heartbeat
+
+go 1.13
+
+require (
+	github.com/gosuri/uilive v0.0.3 // indirect
+	github.com/gosuri/uiprogress v0.0.1
+	github.com/olekukonko/tablewriter v0.0.4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/gosuri/uilive v0.0.3 h1:kvo6aB3pez9Wbudij8srWo4iY6SFTTxTKOkb+uRCE8I=
+github.com/gosuri/uilive v0.0.3/go.mod h1:qkLSc0A5EXSP6B04TrN4oQoxqFI7A8XvoXSlJi8cwk8=
+github.com/gosuri/uiprogress v0.0.1 h1:0kpv/XY/qTmFWl/SkaJykZXrBBzwwadmW8fRb7RJSxw=
+github.com/gosuri/uiprogress v0.0.1/go.mod h1:C1RTYn4Sc7iEyf6j8ft5dyoZ4212h8G1ol9QQluh5+0=
+github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
+github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=


### PR DESCRIPTION
Go modules were introduced in `Go 1.11`. There is no need in `GOPATH` anymore.

In this PR I'm making this repo as a go module adding two files declaring dependecies. This is output of `go mod init` and `go build`.
